### PR TITLE
Ubuntu 22.04 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository is used to automatically build an [eMoflon](https://emoflon.org)
 
 ## Packages/Configuration
 
-- [Ubuntu 20.04](https://app.vagrantup.com/gusztavvargadr/boxes/ubuntu-desktop)
+- [Ubuntu 22.04](https://app.vagrantup.com/gusztavvargadr/boxes/xubuntu-desktop-2204-lts)
 - [OpenJDK 17](https://openjdk.org/projects/jdk/17/)
 - [Graphviz](https://graphviz.org/)
 - [eMoflon IBeX Eclipse build](https://github.com/eMoflon/emoflon-ibex-eclipse-build) (variant: *eclipse-emoflon-linux-user*)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 token = ENV["GITHUB_TOKEN"]
 
 Vagrant.configure("2") do |config|
-    config.vm.box = "gusztavvargadr/ubuntu-desktop-2004-lts-xfce"
+    config.vm.box = "gusztavvargadr/xubuntu-desktop-2204-lts"
     config.vm.define 'emoflon'
     config.vm.provider :virtualbox do |vb|
         vb.name = "emoflon"

--- a/prov.sh
+++ b/prov.sh
@@ -114,7 +114,6 @@ chmod u+x /home/vagrant/Desktop/*.desktop
 
 log "Clean-up"
 sudo apt-get remove -yq \
-        snapd \
         libreoffice-* \
         thunderbird \
         pidgin \


### PR DESCRIPTION
Closes #19.

~The Firefox browser is missing in the new Ubuntu 22.04 base image. Therefore, I added it's installation to the provisioning script.~