### PR TITLE
Changes `apt-get upgrade` to `dist-upgrade` to include major updates

### DIFF
--- a/prov.sh
+++ b/prov.sh
@@ -27,7 +27,7 @@ log "Start provisioning."
 # Updates
 log "Installing updates."
 sudo apt-get update
-sudo apt-get upgrade -y
+sudo apt-get dist-upgrade -y
 
 # Java/JDK21
 log "Installing OpenJDK."


### PR DESCRIPTION
This fixes a broken system state from before.

Closes #53.